### PR TITLE
Remove explicitly specified outdated buildTools

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,6 @@ apply plugin: 'kotlin-android'
 android {
 
     compileSdkVersion 27
-    buildToolsVersion '28.0.0-rc1'
 
     defaultConfig {
         applicationId "com.google.android.samples.dynamicfeatures.ondemand"


### PR DESCRIPTION
AGP 3.x don't need to have buildToolsVersion explicitly specified, it picks the best based on the compileSdkVersion.
Also, the 28.0.0-rc1 version fails to resolve if you have the newer 28.0.0 version.