### PR TITLE
Update include attribute in fusing element

### DIFF
--- a/features/assets/src/main/AndroidManifest.xml
+++ b/features/assets/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
     <dist:module
         dist:onDemand="true"
         dist:title="@string/module_assets">
-        <dist:fusing include="true" />
+        <dist:fusing dist:include="true" />
     </dist:module>
 
 </manifest>

--- a/features/java/src/main/AndroidManifest.xml
+++ b/features/java/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
     <dist:module
         dist:onDemand="true"
         dist:title="@string/module_feature_java">
-        <dist:fusing include="true" />
+        <dist:fusing dist:include="true" />
     </dist:module>
 
     <application>

--- a/features/kotlin/src/main/AndroidManifest.xml
+++ b/features/kotlin/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
     <dist:module
         dist:onDemand="true"
         dist:title="@string/module_feature_kotlin">
-        <dist:fusing include="true" />
+        <dist:fusing dist:include="true" />
     </dist:module>
 
     <application>

--- a/features/native/src/main/AndroidManifest.xml
+++ b/features/native/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
     <dist:module
         dist:onDemand="true"
         dist:title="@string/module_native">
-        <dist:fusing include="true" />
+        <dist:fusing dist:include="true" />
     </dist:module>
 
     <application>


### PR DESCRIPTION
Include attribute in fusing element need to reference "dist:".

It is required to build bundles.