### PR TITLE
Fix error

### DIFF
--- a/features/assets/src/main/AndroidManifest.xml
+++ b/features/assets/src/main/AndroidManifest.xml
@@ -26,5 +26,8 @@
         dist:title="@string/module_assets">
         <dist:fusing dist:include="true" />
     </dist:module>
+  
+    <application
+          android:hasCode="false"/>
 
 </manifest>


### PR DESCRIPTION
When I used the bundletool build-apks
show the next error.

Error: Module 'assets' has no dex files but the attribute 'hasCode' is not set to false in the AndroidManifest.xml.
com.android.tools.build.bundletool.exceptions.ValidationException: Module 'assets' has no dex files but the attribute 'hasCode' is not set to false in the AndroidManifest.xml.